### PR TITLE
Fix receive method

### DIFF
--- a/tests/test_cam.py
+++ b/tests/test_cam.py
@@ -1,8 +1,12 @@
-from matrixscreener.cam import *
+"""Test cam module."""
 import pytest
 
-class EchoSocket:
-    "Dummy echo socket for mocking."
+from matrixscreener.cam import *
+
+
+class EchoSocket(object):
+    """Dummy echo socket for mocking."""
+
     msg = ''
 
     def send(self, msg):
@@ -18,12 +22,17 @@ class EchoSocket:
     def settimeout(self, timeout):
         pass
 
+    def fileno(self):
+        return 0
+
 # TEST
-#- key (here cli) overrided if defined several times
-#- prefix added
-#- types (integer, float) should be converted to strings
+# key (here cli) overrided if defined several times
+# prefix added
+# types (integer, float) should be converted to strings
+
+
 def test_echo(monkeypatch):
-    "Prefix + command sent should be same as echoed socket message."
+    """Prefix + command sent should be same as echoed socket message."""
     # mock socket
     monkeypatch.setattr("socket.socket", EchoSocket)
 
@@ -39,12 +48,13 @@ def test_echo(monkeypatch):
     cam.flush = flush
 
     echoed = cam.send(cmd)[0]
-    sent   = tuples_as_dict(cam.prefix + cmd)
+    sent = tuples_as_dict(cam.prefix + cmd)
 
     assert sent == echoed
 
+
 def test_commands(monkeypatch):
-    "short hand commands should work as intended"
+    """Short hand commands should work as intended."""
     # mock socket
     monkeypatch.setattr("socket.socket", EchoSocket)
 


### PR DESCRIPTION
Hi!

Thanks for the matrixscreener API! Here's something I needed to do to be able to change the PMT gain, for example.

This fix ensures that the server and microscope has time to finish a
command and return a reply, before method receive returns. Some
commands, like change of PMT gain, can take a while to excecute for the
microscope. Start scan command also takes a while before the server
returns a reply.
- Add method _check_socket to check if socket is readable using select.
- Use _check_socket in method receive until socket is readable or after
  timeout of 10 seconds. When socket is readable, call recv on socket.
- Fix PEP issues in cam module.
- Fix docstrings in cam module.
- Add method fileno to mock socket class, in test_cam module, and make
  select work during tests.
- Fix some, but not all, PEP issues in test_cam module.

Best regards,
Martin
